### PR TITLE
Fix filename case

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -17,7 +17,7 @@
   <div id="map" style="position: absolute; top: 0; right: 0; bottom: 0; left: 0; width: 100%; height: 100%"></div>
   
   <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
-  <script src="../dist/leaflet.vector-markers.js"></script>
+  <script src="../dist/Leaflet.vector-markers.js"></script>
   <script>
     var map = L.map('map').setView([48.15491,11.54183], 14);
 


### PR DESCRIPTION
Reference to `Leaflet.vector-markers.js` must be fixed for the file to be correctly loaded in case sensitive systems.