### PR TITLE
Fix bower json error Unexpected token ] in JSON

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,6 @@
   ],
   "ignore": [
     "node_modules",
-    "bower_components",
+    "bower_components"
   ]
 }


### PR DESCRIPTION
This extra `,` will cause bower installation's failure:

```
bower not-cached    https://github.com/hiasinho/Leaflet.vector-markers.git#*
bower resolve       https://github.com/hiasinho/Leaflet.vector-markers.git#*
bower checkout      leaflet.vector-markers#0.0.5
bower EMALFORMED    Failed to read /tmp/shahin/bower/5dca7318ee3361e5724a508b55670d46-32548-tRIz8X/bower.json

Additional error details:
Unexpected token ] in JSON at position 607
```