### PR TITLE
Make prefix optional

### DIFF
--- a/src/Icon.js
+++ b/src/Icon.js
@@ -57,10 +57,10 @@ export default class Icon extends Leaflet.Icon {
     if (options.extraClasses) {
       i.classList.add(options.extraClasses)
     }
-    if (!options.prefix || options.icon.slice(0, options.prefix.length + 1) === options.prefix + '-') {
-      i.classList.add(options.icon)
-    } else {
+    if (options.prefix) {
       i.classList.add(options.prefix + '-' + options.icon)
+    } else {
+      i.classList.add(options.icon)
     }
     if (options.spin && typeof options.spinClass === 'string') {
       i.classList.add(options.spinClass)

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -57,7 +57,7 @@ export default class Icon extends Leaflet.Icon {
     if (options.extraClasses) {
       i.classList.add(options.extraClasses)
     }
-    if (options.icon.slice(0, options.prefix.length + 1) === options.prefix + '-') {
+    if (!options.prefix || options.icon.slice(0, options.prefix.length + 1) === options.prefix + '-') {
       i.classList.add(options.icon)
     } else {
       i.classList.add(options.prefix + '-' + options.icon)


### PR DESCRIPTION
Some icon fonts doesn't use such prefixes (e.g. material design icons).