### PR TITLE
Fix hidden icon with Leaflet 1.0

### DIFF
--- a/src/leaflet-vector-markers.scss
+++ b/src/leaflet-vector-markers.scss
@@ -14,6 +14,10 @@ Version: 0.0.6
   display: block;
   text-align: center;
 
+  svg {
+    position: static !important;
+  }
+
   path {
     stroke: black;
     stroke-opacity: 0.4;


### PR DESCRIPTION
Leaflet 1.0 includes this style:
```
.leaflet-map-pane svg {
    position: absolute;
    left: 0;
    top: 0;
}
```
Marker hides the icon.